### PR TITLE
feat(file-sharing): files are now dynamically send to server

### DIFF
--- a/cmd/cls/client/main.go
+++ b/cmd/cls/client/main.go
@@ -14,8 +14,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if len(fileContent) > 0 {
-		client.SetupTLSClient(fileContent) 
+	if len(fileContent.Content) > 0 {
+		client.SetupTLSClient(&fileContent) 
 	} else {
 		fmt.Println("No file content processed.")
         os.Exit(1)

--- a/internal/arguments/arguments.go
+++ b/internal/arguments/arguments.go
@@ -3,8 +3,6 @@ package arguments
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
-
 	"github.com/nielsjaspers/cls/pkg"
 	"github.com/spf13/cobra"
 )

--- a/internal/client/tls-client.go
+++ b/internal/client/tls-client.go
@@ -38,18 +38,17 @@ func SetupTLSClient(f []byte) {
 
 	// _, err = conn.Write([]byte("Hello Server!\n"))
 	// if err != nil {
-		// log.Printf("Error writing: %v", err)
-		// return
+	// log.Printf("Error writing: %v", err)
+	// return
 	// }
 
-    
-    if len(f) > 0 {
-        _, err = conn.Write(f)
-        if err != nil {
-            log.Printf("Error writing: %v", err)
-            return
-        }
-    }
+	if len(f) > 0 {
+		_, err = conn.Write(f)
+		if err != nil {
+			log.Printf("Error writing: %v", err)
+			return
+		}
+	}
 
 	r := bufio.NewReader(conn)
 	for {
@@ -64,9 +63,9 @@ func SetupTLSClient(f []byte) {
 		}
 
 		log.Printf("Received: %s", msg)
+        // if msg == "You'll be disconnected shortly.\n" {
+            // break
+        // }
 	}
 
 }
-
-
-

--- a/internal/client/tls-client.go
+++ b/internal/client/tls-client.go
@@ -4,14 +4,15 @@ import (
 	"bufio"
 	"crypto/tls"
 	"crypto/x509"
-	"io"
 	"log"
 	"os"
+	"strings"
 
+	"github.com/nielsjaspers/cls/internal/arguments"
 	"github.com/nielsjaspers/cls/secrets"
 )
 
-func SetupTLSClient(f []byte) {
+func SetupTLSClient(f *arguments.FileData) {
 	log.SetFlags(log.Lshortfile)
 
 	cert, err := os.ReadFile(secrets.CertAuthPath)
@@ -33,39 +34,77 @@ func SetupTLSClient(f []byte) {
 		log.Fatalf("Failed to connect to server: %v", err)
 	}
 	defer conn.Close()
-
 	log.Println("Connected to server")
 
-	// _, err = conn.Write([]byte("Hello Server!\n"))
-	// if err != nil {
-	// log.Printf("Error writing: %v", err)
-	// return
-	// }
-
-	if len(f) > 0 {
-		_, err = conn.Write(f)
-		if err != nil {
-			log.Printf("Error writing: %v", err)
-			return
-		}
-	}
-
 	r := bufio.NewReader(conn)
-	for {
-		msg, err := r.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				log.Println("Client disconnected")
-			} else {
-				log.Printf("Error reading: %v", err)
-			}
-			return
-		}
 
-		log.Printf("Received: %s", msg)
-        // if msg == "You'll be disconnected shortly.\n" {
-            // break
-        // }
+	// Send filename
+	filename := f.Filename[:]
+	_, err = conn.Write(filename)
+	if err != nil {
+		log.Printf("Error sending filename: %v", err)
+		return
+	}
+	log.Println("Filename sent, waiting for response...")
+
+	// Wait for "NEXT_ITEM"
+	if !waitForNextItem(r) {
+		return
 	}
 
+	// Send file extension
+	extension := f.Extension[:]
+	_, err = conn.Write(extension)
+	if err != nil {
+		log.Printf("Error sending file extension: %v", err)
+		return
+	}
+	log.Println("File extension sent, waiting for response...")
+
+	// Wait for "NEXT_ITEM"
+	if !waitForNextItem(r) {
+		return
+	}
+
+	// Send file content
+	_, err = conn.Write(f.Content)
+	if err != nil {
+		log.Printf("Error sending file content: %v", err)
+		return
+	}
+	log.Println("File content sent, waiting for final confirmation...")
+
+	// Send an EOF marker
+	_, err = conn.Write([]byte("EXIT_EOF_EXIT_EOF\n"))
+	if err != nil {
+		log.Printf("Error sending EOF marker: %v", err)
+		return
+	}
+
+	// Wait for the final message
+	finalMsg, err := r.ReadString('\n')
+	if err != nil {
+		log.Printf("Error reading final confirmation: %v", err)
+		return
+	}
+	log.Printf("Received from server: %s", strings.TrimSpace(finalMsg))
+
+	log.Println("Transfer complete, disconnecting.")
+}
+
+func waitForNextItem(r *bufio.Reader) bool {
+	msg, err := r.ReadString('\n')
+	if err != nil {
+		log.Printf("Error reading server response: %v", err)
+		return false
+	}
+
+	msg = strings.TrimSpace(msg)
+	if msg != "NEXT_ITEM" {
+		log.Printf("Unexpected server response: %s", msg)
+		return false
+	}
+
+	log.Println("Received NEXT_ITEM, proceeding to the next step.")
+	return true
 }

--- a/internal/server/tls-server.go
+++ b/internal/server/tls-server.go
@@ -63,7 +63,7 @@ func handleConnection(conn net.Conn) {
 
 	// Specify the file path 
     // Currently hardcoded as this is a proof of concept
-	filePath := "~/received/received_file.jpeg" 
+	filePath := "~/received/received_file.zip" 
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -82,7 +82,7 @@ func handleConnection(conn net.Conn) {
 
 	// Read file content from connection and write it to the file
 	r := bufio.NewReader(conn)
-	buf := make([]byte, 4096) // 4KB chunks
+	buf := make([]byte, 131072) // 128 kB chunks
 	for {
 		n, err := r.Read(buf)
 		if err != nil {
@@ -93,19 +93,21 @@ func handleConnection(conn net.Conn) {
 			log.Printf("Error reading: %v", err)
 			return
 		}
+        log.Printf("File successfully saved to %s", filePath)
 
+        // Respond to the client
+        // TODO - Make this send once after file has been fully received
+        _, err = conn.Write([]byte("File received successfully!\n"))
+
+        if err != nil {
+            log.Printf("Error writing to client: %v", err)
+        }
+        
 		if _, err := file.Write(buf[:n]); err != nil {
 			log.Printf("Error writing to file: %v", err)
 			return
 		}
 	}
 
-	log.Printf("File successfully saved to %s", filePath)
-
-	// Respond to the client
-	_, err = conn.Write([]byte("File received successfully!\n"))
-	if err != nil {
-		log.Printf("Error writing to client: %v", err)
-	}
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of file data and the communication protocol between the client and server in the `cls` application. The most important changes include the introduction of a new `FileData` struct, updates to the `ExecuteCommand` function, and enhancements to the `SetupTLSClient` and `handleConnection` functions.

### Introduction of `FileData` struct:
* [`internal/arguments/arguments.go`](diffhunk://#diff-958c681faaf5f51aa3ccef575b21c45f8a6b170fba7690d1a1823464d9708da3L5-R18): Added `FileData` struct to encapsulate file content, filename, and file extension.

### Updates to `ExecuteCommand` function:
* [`internal/arguments/arguments.go`](diffhunk://#diff-958c681faaf5f51aa3ccef575b21c45f8a6b170fba7690d1a1823464d9708da3L26-R63): Modified `ExecuteCommand` to use `FileData` and populate its fields with file content, filename, and extension.

### Enhancements to `SetupTLSClient` function:
* [`internal/client/tls-client.go`](diffhunk://#diff-8c4657f7f794b224dd08b52bf83c93ab569e6c881c7e888fe612be8ca651fe2fL7-R15): Updated `SetupTLSClient` to accept a pointer to `FileData` and send the filename, file extension, and file content to the server in separate steps, with appropriate responses. [[1]](diffhunk://#diff-8c4657f7f794b224dd08b52bf83c93ab569e6c881c7e888fe612be8ca651fe2fL7-R15) [[2]](diffhunk://#diff-8c4657f7f794b224dd08b52bf83c93ab569e6c881c7e888fe612be8ca651fe2fL36-R110)

### Enhancements to `handleConnection` function:
* [`internal/server/tls-server.go`](diffhunk://#diff-ca7f8d08e6f77c91d087a9d22e341b7591d279c1f82c7799ac5a5258d148c6a0L61-R128): Modified `handleConnection` to read the filename, file extension, and file content from the client, and respond with "NEXT_ITEM" after each step. Added handling for an EOF marker to indicate the end of file transfer. [[1]](diffhunk://#diff-ca7f8d08e6f77c91d087a9d22e341b7591d279c1f82c7799ac5a5258d148c6a0L61-R128) [[2]](diffhunk://#diff-ca7f8d08e6f77c91d087a9d22e341b7591d279c1f82c7799ac5a5258d148c6a0L105-L111)
