### PR TITLE
feat(server-path): custom path for incoming files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.23.3
+
+# Set the working directory inside the container
+WORKDIR /cls
+
+# Copy the Go modules and install dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code
+COPY . .
+
+# Build the application
+RUN go build cmd/cls/server/main.go
+
+# Expose the port your app runs on
+EXPOSE 443
+
+RUN mkdir ~/received
+
+# Command to run the application
+CMD ["./main"]
+

--- a/cmd/cls/server/main.go
+++ b/cmd/cls/server/main.go
@@ -1,18 +1,11 @@
 package main
 
 import (
-	"fmt"
-	"os"
 
 	"github.com/nielsjaspers/cls/internal/server"
 )
 
 func main() {
-	args, _ := server.InitRemotePath()
-	if err := args.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	server.SetupTLSServer()
+    serverPath := server.ExecuteRemotePath()
+	server.SetupTLSServer(serverPath)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.23.3
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
+	github.com/spf13/cobra v1.8.1 // direct 
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/internal/server/filesystem.go
+++ b/internal/server/filesystem.go
@@ -3,15 +3,12 @@ package server
 import (
 	"log"
 	"os"
-
 	"github.com/spf13/cobra"
 )
 
-func InitRemotePath() (*cobra.Command, error) {
-    return handleServerCmds()
-}
-
-func handleServerCmds() (*cobra.Command, error) {
+// ExecuteRemotePath runs the server root command and returns a filepath string
+func ExecuteRemotePath() string {
+    var serverFilePath string
 
 	var rootCmd = &cobra.Command{
 		Use:   "cls",
@@ -29,13 +26,21 @@ func handleServerCmds() (*cobra.Command, error) {
 			"-P",
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := os.MkdirAll(args[0], os.ModePerm); err != nil {
+            fpath := args[0]
+			if err := os.MkdirAll(fpath, os.ModePerm); err != nil {
 				log.Fatalf("Error while creating directory '%v': %v", args[0], err)
 			}
+            serverFilePath = fpath
 		},
 	}
 
-    rootCmd.AddCommand(remotePathCmd)
-    
-    return rootCmd, nil
+	rootCmd.AddCommand(remotePathCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		panic(err)
+		// return nil, err
+	}
+
+    return serverFilePath
+
 }

--- a/internal/server/tls-server.go
+++ b/internal/server/tls-server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/nielsjaspers/cls/secrets"
 )
 
-func SetupTLSServer() {
+func SetupTLSServer(fp string) {
 	log.SetFlags(log.Lshortfile)
 
 	certificate, err := tls.LoadX509KeyPair(secrets.ServerCrtPath, secrets.ServerKeyPath)
@@ -51,12 +51,13 @@ func SetupTLSServer() {
 		} else {
 			log.Println("Received non-TLS connection")
 		}
-		go handleConnection(conn)
+		go handleConnection(conn, fp)
 	}
 
 }
 
-func handleConnection(conn net.Conn) {
+func handleConnection(conn net.Conn, fp string) {
+    fmt.Printf("Given path: %v\n", fp)
 	defer conn.Close()
 
 	r := bufio.NewReader(conn)
@@ -95,16 +96,21 @@ func handleConnection(conn net.Conn) {
 		return
 	}
 
-	filePath := fmt.Sprintf("%s", filename)
+    var filePath string
+    if fp == ""{
+        filePath = fmt.Sprintf("%s", filename)
+    } else {
+        filePath = fmt.Sprintf("%s/%s", fp, filename)
+    }
 
 	// Open the file for writing
-	homeDir, err := os.UserHomeDir()
-	file, err := os.Create(homeDir + "/" + filePath)
-	if err != nil {
-		log.Printf("Error creating file: %v", err)
-		return
-	}
-	defer file.Close()
+    file, err := os.Create(filePath)
+    if err != nil {
+        log.Printf("Error creating file: %v", err)
+        return
+    }
+    defer file.Close()
+ 
 
 	// Listen for file content (no max size)
 	buf := make([]byte, 131072) // 128 kB chunks


### PR DESCRIPTION
This pull request includes several important changes to the `cls` project, focusing on Dockerfile creation, refactoring server initialization, and modifying TLS server setup. The most significant changes include the addition of a Dockerfile, refactoring the server initialization process, and updating the TLS server to handle a file path parameter.

### Dockerfile addition:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R23): Added a new Dockerfile to build and run the Go application in a container. This includes setting the working directory, copying dependencies and source code, building the application, and exposing the necessary port.

### Refactoring server initialization:
* [`cmd/cls/server/main.go`](diffhunk://#diff-e716be764117ce8afec2e5524a9a3c09a1d63b05b0a739a8a1c2b88ba68caa32L4-R10): Refactored the main function to use the new `ExecuteRemotePath` function for server initialization and pass the server path to `SetupTLSServer`.
* [`internal/server/filesystem.go`](diffhunk://#diff-2996d7fd84fa467b9d2d412727509ac82fc765bf2259bc66f02a3f6020981459L6-R11): Replaced `InitRemotePath` and `handleServerCmds` with `ExecuteRemotePath`, which now returns a file path string directly. [[1]](diffhunk://#diff-2996d7fd84fa467b9d2d412727509ac82fc765bf2259bc66f02a3f6020981459L6-R11) [[2]](diffhunk://#diff-2996d7fd84fa467b9d2d412727509ac82fc765bf2259bc66f02a3f6020981459L32-R45)

### TLS server setup:
* [`internal/server/tls-server.go`](diffhunk://#diff-ca7f8d08e6f77c91d087a9d22e341b7591d279c1f82c7799ac5a5258d148c6a0L16-R16): Updated `SetupTLSServer` and `handleConnection` functions to accept a file path parameter, allowing the server to use a specified path for handling connections. [[1]](diffhunk://#diff-ca7f8d08e6f77c91d087a9d22e341b7591d279c1f82c7799ac5a5258d148c6a0L16-R16) [[2]](diffhunk://#diff-ca7f8d08e6f77c91d087a9d22e341b7591d279c1f82c7799ac5a5258d148c6a0L54-R60) [[3]](diffhunk://#diff-ca7f8d08e6f77c91d087a9d22e341b7591d279c1f82c7799ac5a5258d148c6a0L98-R114)

Resolves #5 